### PR TITLE
[5.3] fixed document of AdGroupService, AdGroupOperation according to wsdl

### DIFF
--- a/docs/en/api_reference/data/AdGroupOperation.md
+++ b/docs/en/api_reference/data/AdGroupOperation.md
@@ -3,12 +3,11 @@ AdGroupOperation displays target ad group information and its operation results.
 ### Service
 + [AdGroupService](../services/AdGroupService.md)
 
-| Field | Data Type | Description | Restrictions | 
+| Field | Data Type | Description | Restrictions |
 |---|---|---|---|
 | Operation(inherited)||||
 | operator| enum <a href="./Operator.md">Operator</a>| Operator. This field is required and should not be null.| Req |
 | AdGroupOperation||||
 | accountId| xsd:long| account ID.| Req |
-| campaignId| xsd:long| campaign ID.| Req |
 | operand[]| <a href="./AdGroup.md">AdGroup</a>| AdGroup to operate on This field is required and should not be null.| Req |
 <a rel="license" href="http://creativecommons.org/licenses/by-nd/2.1/jp/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by-nd/2.1/jp/88x31.png" /></a><br />この 作品 は <a rel="license" href="http://creativecommons.org/licenses/by-nd/2.1/jp/">クリエイティブ・コモンズ 表示 - 改変禁止 2.1 日本 ライセンスの下に提供されています。</a>

--- a/docs/en/api_reference/services/AdGroupService.md
+++ b/docs/en/api_reference/services/AdGroupService.md
@@ -448,7 +448,7 @@ Updates ad group.
             <ns1:operations>
                 <ns1:operator>SET</ns1:operator>
                 <ns1:accountId>xxxxxxxx</ns1:accountId>
-                <!--ManualCPCへ変更-->
+                <!--ManualCPC-->
                 <ns1:operand>
                     <ns1:accountId>xxxxxxxx</ns1:accountId>
                     <ns1:campaignId>xxxxxxxx</ns1:campaignId>
@@ -462,7 +462,7 @@ Updates ad group.
                        </ns1:initialBid>
                     </ns1:biddingStrategyConfiguration>
                 </ns1:operand>
-                <!--EnhancedCpcBiddingへ変更-->
+                <!--EnhancedCpcBidding-->
                 <ns1:operand>
                     <ns1:accountId>xxxxxxxx</ns1:accountId>
                     <ns1:campaignId>xxxxxxxx</ns1:campaignId>

--- a/docs/en/api_reference/services/AdGroupService.md
+++ b/docs/en/api_reference/services/AdGroupService.md
@@ -15,9 +15,9 @@ Explains the operation which provides at AdGroupService.
 ### Request
 Gets adgroup information.
 
-| Field | Restrictions | Data Type | Description | 
+| Field | Restrictions | Data Type | Description |
 |---|---|---|---|
-| selector | Req | [AdGroupSelector](../data/AdGroupSelector.md) | Ad Group Selector. | 
+| selector | Req | [AdGroupSelector](../data/AdGroupSelector.md) | Ad Group Selector. |
 
 ##### Request Sample
 ```xml
@@ -54,9 +54,9 @@ Gets adgroup information.
 ### Response
 Response Fields
 
-| Field | Data Type | Description | 
+| Field | Data Type | Description |
 |---|---|---|
-| rval | [AdGroupPage](../data/AdGroupPage.md) | List of adgroups identified by the AdGroupSelector. | 
+| rval | [AdGroupPage](../data/AdGroupPage.md) | List of adgroups identified by the AdGroupSelector. |
 
 ##### Response Sample
 ```xml
@@ -235,9 +235,9 @@ Response Fields
 ### Request
 Adds ad group.
 
-| Field | Restrictions | Data Type | Description | 
+| Field | Restrictions | Data Type | Description |
 |---|---|---|---|
-| operations | Req | [AdGroupOperation](../data/AdGroupOperation.md) | List of unique operations. <br>The same ad group cannot be specified in more than one operation. | 
+| operations | Req | [AdGroupOperation](../data/AdGroupOperation.md) | List of unique operations. <br>The same ad group cannot be specified in more than one operation. |
 
 ##### Request Sample
 ```xml
@@ -261,7 +261,6 @@ Adds ad group.
             <ns1:operations>
                <ns1:operator>ADD</ns1:operator>
                <ns1:accountId>xxxxxxxx</ns1:accountId>
-               <ns1:campaignId>xxxxxxxx</ns1:campaignId>
                <!--ManualCPC-->
                <ns1:operand>
                   <ns1:accountId>xxxxxxxx</ns1:accountId>
@@ -308,9 +307,9 @@ Adds ad group.
 ### Response
 Response Field
 
-| Field | Data Type | Description | 
+| Field | Data Type | Description |
 |---|---|---|
-| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | The updated ad groups. | 
+| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | The updated ad groups. |
 
 ##### Response Sample
 ```xml
@@ -423,9 +422,9 @@ Response Field
 ### Request
 Updates ad group.
 
-| Field | Restrictions | Data Type | Description | 
+| Field | Restrictions | Data Type | Description |
 |---|---|---|---|
-| operations | Req | [AdGroupOperation](../data/AdGroupOperation.md) | List of unique operations. <br>The same ad group cannot be specified in more than one operation. | 
+| operations | Req | [AdGroupOperation](../data/AdGroupOperation.md) | List of unique operations. <br>The same ad group cannot be specified in more than one operation. |
 
 ##### Request Sample
 ```xml
@@ -449,7 +448,6 @@ Updates ad group.
             <ns1:operations>
                 <ns1:operator>SET</ns1:operator>
                 <ns1:accountId>xxxxxxxx</ns1:accountId>
-                <ns1:campaignId>xxxxxxxx</ns1:campaignId>
                 <!--ManualCPCへ変更-->
                 <ns1:operand>
                     <ns1:accountId>xxxxxxxx</ns1:accountId>
@@ -494,9 +492,9 @@ Updates ad group.
 ### Response
 Response Field
 
-| Field | Data Type | Description | 
+| Field | Data Type | Description |
 |---|---|---|
-| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | The updated ad groups. | 
+| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | The updated ad groups. |
 
 ##### Response Sample
 ```xml
@@ -603,9 +601,9 @@ Response Field
 ### Request
 Removes ad group.
 
-| Field | Restrictions | Data Type | Description | 
+| Field | Restrictions | Data Type | Description |
 |---|---|---|---|
-| operations | Req | [AdGroupOperation](../data/AdGroupOperation.md) | List of unique operations. <br>The same ad group cannot be specified in more than one operation. | 
+| operations | Req | [AdGroupOperation](../data/AdGroupOperation.md) | List of unique operations. <br>The same ad group cannot be specified in more than one operation. |
 
 ##### Request Sample
 ```xml
@@ -628,7 +626,6 @@ xmlns:ns1="http://ss.yahooapis.jp/V5">
             <ns1:operations>
                 <ns1:operator>REMOVE</ns1:operator>
                 <ns1:accountId>xxxxxxxx</ns1:accountId>
-                <ns1:campaignId>xxxxxxxx</ns1:campaignId>
                 <ns1:operand>
                     <ns1:accountId>xxxxxxxx</ns1:accountId>
                     <ns1:campaignId>xxxxxxxx</ns1:campaignId>
@@ -647,9 +644,9 @@ xmlns:ns1="http://ss.yahooapis.jp/V5">
 ### Response
 Response Fields
 
-| Field | Data Type | Description | 
+| Field | Data Type | Description |
 |---|---|---|
-| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | The updated ad groups. | 
+| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | The updated ad groups. |
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/docs/ja/api_reference/data/AdGroupOperation.md
+++ b/docs/ja/api_reference/data/AdGroupOperation.md
@@ -3,12 +3,11 @@ AdGroupOperationオブジェクトは、操作の対象となる広告グルー�
 ### Service
 + [AdGroupService](../services/AdGroupService.md)
 
-| フィールド | データ型 | 説明 | ADD | SET | REMOVE | 
+| フィールド | データ型 | 説明 | ADD | SET | REMOVE |
 |---|---|---|---|---|---|
 | Operation(inherited)||||||
 | operator| enum <a href="./Operator.md">Operator</a>| 処理を表す演算子です。| Req| Req| Req |
 | AdGroupOperation||||||
 | accountId| xsd:long| アカウントIDです。| Req| Req| Req |
-| campaignId| xsd:long| キャンペーンIDです。| Req| Req| Req |
 | operand[]| <a href="./AdGroup.md">AdGroup</a>| AdGroupオブジェクトの配列です。各配列には処理の対象となる広告グループの情報が含まれます。| Req| Req| Req |
 <a rel="license" href="http://creativecommons.org/licenses/by-nd/2.1/jp/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by-nd/2.1/jp/88x31.png" /></a><br />この 作品 は <a rel="license" href="http://creativecommons.org/licenses/by-nd/2.1/jp/">クリエイティブ・コモンズ 表示 - 改変禁止 2.1 日本 ライセンスの下に提供されています。</a>

--- a/docs/ja/api_reference/services/AdGroupService.md
+++ b/docs/ja/api_reference/services/AdGroupService.md
@@ -16,9 +16,9 @@ AdGroupServiceで提供される操作を説明します。
 広告グループに関する情報を取得します。
 
 #### リクエスト
-| パラメータ | 必須 | データ型 | 説明 | 
+| パラメータ | 必須 | データ型 | 説明 |
 |---|---|---|---|
-| selector | ○ | [AdGroupSelector](../data/AdGroupSelector.md) | 操作の対象とする広告グループです。 | 
+| selector | ○ | [AdGroupSelector](../data/AdGroupSelector.md) | 操作の対象とする広告グループです。 |
 ##### ＜リクエストサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -54,9 +54,9 @@ AdGroupServiceで提供される操作を説明します。
 #### レスポンス
 正常時のレスポンスフィールド
 
-| フィールド | データ型 | 説明 | 
+| フィールド | データ型 | 説明 |
 |---|---|---|
-| rval | [AdGroupPage](../data/AdGroupPage.md) | 取得される広告グループのエントリーです。 | 
+| rval | [AdGroupPage](../data/AdGroupPage.md) | 取得される広告グループのエントリーです。 |
 ##### ＜レスポンスサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -233,9 +233,9 @@ AdGroupServiceで提供される操作を説明します。
 広告グループを追加します。
 
 #### リクエスト
-| パラメータ | 必須 | 値 | 説明 | 
+| パラメータ | 必須 | 値 | 説明 |
 |---|---|---|---|
-| operations | ○ | [AdGroupOperation](../data/AdGroupOperation.md) | 操作の対象となる広告グループと処理の内容です。 | 
+| operations | ○ | [AdGroupOperation](../data/AdGroupOperation.md) | 操作の対象となる広告グループと処理の内容です。 |
 ##### ＜リクエストサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -258,7 +258,6 @@ AdGroupServiceで提供される操作を説明します。
             <ns1:operations>
                <ns1:operator>ADD</ns1:operator>
                <ns1:accountId>xxxxxxxx</ns1:accountId>
-               <ns1:campaignId>xxxxxxxx</ns1:campaignId>
                <!--ManualCPC-->
                <ns1:operand>
                   <ns1:accountId>xxxxxxxx</ns1:accountId>
@@ -305,9 +304,9 @@ AdGroupServiceで提供される操作を説明します。
 #### レスポンス
 正常時のレスポンスフィールド
 
-| フィールド | データ型 | 説明 | 
+| フィールド | データ型 | 説明 |
 |---|---|---|
-| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | 操作結果を含む広告グループに関する情報のコンテナです。 | 
+| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | 操作結果を含む広告グループに関する情報のコンテナです。 |
 ##### ＜レスポンスサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -420,9 +419,9 @@ AdGroupServiceで提供される操作を説明します。
 広告グループを更新します。
 
 #### リクエスト
-| パラメータ | 必須 | 値 | 説明 | 
+| パラメータ | 必須 | 値 | 説明 |
 |---|---|---|---|
-| operations | ○ | [AdGroupOperation](../data/AdGroupOperation.md) | 操作の対象となる広告グループと処理の内容です。 | 
+| operations | ○ | [AdGroupOperation](../data/AdGroupOperation.md) | 操作の対象となる広告グループと処理の内容です。 |
 ##### ＜リクエストサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -445,7 +444,6 @@ AdGroupServiceで提供される操作を説明します。
             <ns1:operations>
                 <ns1:operator>SET</ns1:operator>
                 <ns1:accountId>xxxxxxxx</ns1:accountId>
-                <ns1:campaignId>xxxxxxxx</ns1:campaignId>
                 <!--ManualCPCへ変更-->
                 <ns1:operand>
                     <ns1:accountId>xxxxxxxx</ns1:accountId>
@@ -490,9 +488,9 @@ AdGroupServiceで提供される操作を説明します。
 #### レスポンス
 正常時のレスポンスフィールド
 
-| フィールド | データ型 | 説明 | 
+| フィールド | データ型 | 説明 |
 |---|---|---|
-| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | 操作結果を含む広告グループに関する情報のコンテナです。 | 
+| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | 操作結果を含む広告グループに関する情報のコンテナです。 |
 ##### ＜レスポンスサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -598,9 +596,9 @@ AdGroupServiceで提供される操作を説明します。
 広告グループを削除します。
 
 #### リクエスト
-| パラメータ | 必須 | 値 | 説明 | 
+| パラメータ | 必須 | 値 | 説明 |
 |---|---|---|---|
-| operations | ○ | [AdGroupOperation](../data/AdGroupOperation.md) | 操作の対象となる広告グループと処理の内容です。 | 
+| operations | ○ | [AdGroupOperation](../data/AdGroupOperation.md) | 操作の対象となる広告グループと処理の内容です。 |
 ##### ＜リクエストサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -622,7 +620,6 @@ xmlns:ns1="http://ss.yahooapis.jp/V5">
             <ns1:operations>
                 <ns1:operator>REMOVE</ns1:operator>
                 <ns1:accountId>xxxxxxxx</ns1:accountId>
-                <ns1:campaignId>xxxxxxxx</ns1:campaignId>
                 <ns1:operand>
                     <ns1:accountId>xxxxxxxx</ns1:accountId>
                     <ns1:campaignId>xxxxxxxx</ns1:campaignId>
@@ -641,9 +638,9 @@ xmlns:ns1="http://ss.yahooapis.jp/V5">
 #### レスポンス
 正常時のレスポンスフィールド
 
-| フィールド | データ型 | 説明 | 
+| フィールド | データ型 | 説明 |
 |---|---|---|
-| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | 操作結果を含む広告グループに関する情報のコンテナです。 | 
+| rval | [AdGroupReturnValue](../data/AdGroupReturnValue.md) | 操作結果を含む広告グループに関する情報のコンテナです。 |
 ##### ＜レスポンスサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
`campaignId` is removed from `AdGroupOperation` object in [WSDL of V5.3 AdGroupService](https://github.com/yahoojp-marketing/sponsored-search-api-documents/blob/5.3/wsdl/AdGroupService.wsdl#L234-L243) while the [document](https://github.com/yahoojp-marketing/sponsored-search-api-documents/blob/5.3/docs/ja/api_reference/data/AdGroupOperation.md) says it is required.
Which is correct?
If doc is valid, please fix wsdl. If wsdl is correct, you can fix it by merging this PR.
Thanks. 

---

V5.3 AdGroupServiceのWSDLではAdGroupOperationからcampaignIdが削除されていますが、ドキュメント上では必須項目とされています。
正しいのはどちらでしょうか？
ドキュメントが正しいのであれば、WSDLを訂正してください。もしWSDLが正しいのであれば、このPRをマージしてドキュメントを更新していただければと思います。
よろしくお願いいたします。