### PR TITLE
Update API version used in `bestpractice` to V6

### DIFF
--- a/docs/en/bestpractice/addisplayoption.md
+++ b/docs/en/bestpractice/addisplayoption.md
@@ -47,7 +47,7 @@ For this example, each Ad Display Option will be added to the account of company
 ##### <Request Sample> [For QUICKLINK]
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -153,7 +153,7 @@ For this example, each Ad Display Option will be added to the account of company
 ##### <Response Sample> [For QUICKLINK]
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>FeedItemService</ns1:service>
@@ -295,7 +295,7 @@ For this example, each Ad Display Option will be added to the account of company
 ##### <Request Sample> [For CALLEXTENSION]
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -325,7 +325,7 @@ For this example, each Ad Display Option will be added to the account of company
 ##### <Response Sample> [For CALLEXTENSION]
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>FeedItemService</ns1:service>
@@ -364,7 +364,7 @@ For this example, QuickLink[No.1-4] and CallExtension[No.1] will be set to campa
 ##### <Request Sample>
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -413,7 +413,7 @@ For this example, QuickLink[No.1-4] and CallExtension[No.1] will be set to campa
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -485,7 +485,7 @@ For this example, QuickLink[No.5] will be set to ad group.
 ##### <Request Sample>
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -529,7 +529,7 @@ For this example, QuickLink[No.5] will be set to ad group.
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -587,7 +587,7 @@ For this example, QuickLink[No.1] will be deleted and QuickLink[No.6] will be se
 ##### <Request Sample> [For QUICKLINK]
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -636,7 +636,7 @@ For this example, QuickLink[No.1] will be deleted and QuickLink[No.6] will be se
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -707,7 +707,7 @@ For this example, QuickLink[No.1] will be deleted and QuickLink[No.6] will be se
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -778,7 +778,7 @@ For this example, QuickLink[No.1] will be deleted and QuickLink[No.6] will be se
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -813,7 +813,7 @@ For this example, QuickLink[No.5] will be deleted and QuickLink[No.7] will be se
 ##### <Request Sample>
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -848,7 +848,7 @@ For this example, QuickLink[No.5] will be deleted and QuickLink[No.7] will be se
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -890,7 +890,7 @@ The call center has been abolished, so the setting of CallExtension to the ad gr
 ##### <Request Sample>
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -923,7 +923,7 @@ The call center has been abolished, so the setting of CallExtension to the ad gr
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>

--- a/docs/en/bestpractice/autoinsert_data.md
+++ b/docs/en/bestpractice/autoinsert_data.md
@@ -100,41 +100,41 @@ For this example, "Sale product list" will be added to the account of company A 
 ##### Request Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:v5="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
-      <v5:RequestHeader>
-         <v5:license>XXXX-XXXX-XXXX-XXXX</v5:license>
-         <v5:apiAccountId>XXXX-XXXX-XXXX-XXXX</v5:apiAccountId>
-         <v5:apiAccountPassword>passwd</v5:apiAccountPassword>
-         <v5:accountId>100000001</v5:accountId>
-         <v5:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</v5:onBehalfOfAccountId>
-         <v5:onBehalfOfPassword>passwd2</v5:onBehalfOfPassword>
-      </v5:RequestHeader>
+      <ns1:RequestHeader>
+         <ns1:license>XXXX-XXXX-XXXX-XXXX</ns1:license>
+         <ns1:apiAccountId>XXXX-XXXX-XXXX-XXXX</ns1:apiAccountId>
+         <ns1:apiAccountPassword>passwd</ns1:apiAccountPassword>
+         <ns1:accountId>100000001</ns1:accountId>
+         <ns1:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</ns1:onBehalfOfAccountId>
+         <ns1:onBehalfOfPassword>passwd2</ns1:onBehalfOfPassword>
+      </ns1:RequestHeader>
    </soapenv:Header>
    <soapenv:Body>
-      <v5:mutate>
-         <v5:operations>
-            <v5:operator>ADD</v5:operator>
-            <v5:accountId>100000001</v5:accountId>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderName>Sale product list</v5:feedFolderName>
-               <v5:feedAttribute>
-                  <v5:feedAttributeName>Product</v5:feedAttributeName>
-                  <v5:placeholderField>AD_CUSTOMIZER_STRING</v5:placeholderField>
-               </v5:feedAttribute>
-               <v5:feedAttribute>
-                  <v5:feedAttributeName>Price</v5:feedAttributeName>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-               </v5:feedAttribute>
-               <v5:feedAttribute>
-                  <v5:feedAttributeName>Last sale date</v5:feedAttributeName>
-                  <v5:placeholderField>AD_CUSTOMIZER_DATE</v5:placeholderField>
-               </v5:feedAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-            </v5:operand>
-         </v5:operations>
-      </v5:mutate>
+      <ns1:mutate>
+         <ns1:operations>
+            <ns1:operator>ADD</ns1:operator>
+            <ns1:accountId>100000001</ns1:accountId>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderName>Sale product list</ns1:feedFolderName>
+               <ns1:feedAttribute>
+                  <ns1:feedAttributeName>Product</ns1:feedAttributeName>
+                  <ns1:placeholderField>AD_CUSTOMIZER_STRING</ns1:placeholderField>
+               </ns1:feedAttribute>
+               <ns1:feedAttribute>
+                  <ns1:feedAttributeName>Price</ns1:feedAttributeName>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+               </ns1:feedAttribute>
+               <ns1:feedAttribute>
+                  <ns1:feedAttributeName>Last sale date</ns1:feedAttributeName>
+                  <ns1:placeholderField>AD_CUSTOMIZER_DATE</ns1:placeholderField>
+               </ns1:feedAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+            </ns1:operand>
+         </ns1:operations>
+      </ns1:mutate>
    </soapenv:Body>
 </soapenv:Envelope>
 ```
@@ -142,7 +142,7 @@ For this example, "Sale product list" will be added to the account of company A 
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>FeedFolderService</ns1:service>
@@ -192,97 +192,97 @@ Next, use FeedItemService to set data to be inserted or to be set to the FeedFol
 ##### Request Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:v5="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
-      <v5:RequestHeader>
-         <v5:license>XXXX-XXXX-XXXX-XXXX</v5:license>
-         <v5:apiAccountId>XXXX-XXXX-XXXX-XXXX</v5:apiAccountId>
-         <v5:apiAccountPassword>passwd</v5:apiAccountPassword>
-         <v5:accountId>100000001</v5:accountId>
-         <v5:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</v5:onBehalfOfAccountId>
-         <v5:onBehalfOfPassword>passwd2</v5:onBehalfOfPassword>
-      </v5:RequestHeader>
+      <ns1:RequestHeader>
+         <ns1:license>XXXX-XXXX-XXXX-XXXX</ns1:license>
+         <ns1:apiAccountId>XXXX-XXXX-XXXX-XXXX</ns1:apiAccountId>
+         <ns1:apiAccountPassword>passwd</ns1:apiAccountPassword>
+         <ns1:accountId>100000001</ns1:accountId>
+         <ns1:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</ns1:onBehalfOfAccountId>
+         <ns1:onBehalfOfPassword>passwd2</ns1:onBehalfOfPassword>
+      </ns1:RequestHeader>
    </soapenv:Header>
    <soapenv:Body>
-      <v5:mutate>
-         <v5:operations>
-            <v5:operator>ADD</v5:operator>
-            <v5:accountId>100000001</v5:accountId>
-            <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>20001</v5:feedFolderId>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_STRING</v5:placeholderField>
-                  <v5:feedAttributeId>1</v5:feedAttributeId>
-                  <v5:feedAttributeValue>Product 101</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-                  <v5:feedAttributeId>2</v5:feedAttributeId>
-                  <v5:feedAttributeValue>100</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_DATE</v5:placeholderField>
-                  <v5:feedAttributeId>3</v5:feedAttributeId>
-                  <v5:feedAttributeValue>20151231 000000</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-               <v5:targetingAdGroup>
-                  <v5:targetingAdGroupId>600001</v5:targetingAdGroupId>
-               </v5:targetingAdGroup>
-            </v5:operand>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>20001</v5:feedFolderId>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_STRING</v5:placeholderField>
-                  <v5:feedAttributeId>1</v5:feedAttributeId>
-                  <v5:feedAttributeValue>Product 102</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-                  <v5:feedAttributeId>2</v5:feedAttributeId>
-                  <v5:feedAttributeValue>300</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_DATE</v5:placeholderField>
-                  <v5:feedAttributeId>3</v5:feedAttributeId>
-                  <v5:feedAttributeValue>20151231 000000</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-            </v5:operand>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>53161</v5:feedFolderId>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_STRING</v5:placeholderField>
-                  <v5:feedAttributeId>1</v5:feedAttributeId>
-                  <v5:feedAttributeValue>Product 103</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-                  <v5:feedAttributeId>2</v5:feedAttributeId>
-                  <v5:feedAttributeValue>1,000</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_DATE</v5:placeholderField>
-                  <v5:feedAttributeId>3</v5:feedAttributeId>
-                  <v5:feedAttributeValue>20151231 000000</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-            </v5:operand>
-         </v5:operations>
-      </v5:mutate>
+      <ns1:mutate>
+         <ns1:operations>
+            <ns1:operator>ADD</ns1:operator>
+            <ns1:accountId>100000001</ns1:accountId>
+            <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>20001</ns1:feedFolderId>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_STRING</ns1:placeholderField>
+                  <ns1:feedAttributeId>1</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>Product 101</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+                  <ns1:feedAttributeId>2</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>100</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_DATE</ns1:placeholderField>
+                  <ns1:feedAttributeId>3</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>20151231 000000</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+               <ns1:targetingAdGroup>
+                  <ns1:targetingAdGroupId>600001</ns1:targetingAdGroupId>
+               </ns1:targetingAdGroup>
+            </ns1:operand>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>20001</ns1:feedFolderId>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_STRING</ns1:placeholderField>
+                  <ns1:feedAttributeId>1</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>Product 102</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+                  <ns1:feedAttributeId>2</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>300</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_DATE</ns1:placeholderField>
+                  <ns1:feedAttributeId>3</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>20151231 000000</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+            </ns1:operand>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>53161</ns1:feedFolderId>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_STRING</ns1:placeholderField>
+                  <ns1:feedAttributeId>1</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>Product 103</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+                  <ns1:feedAttributeId>2</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>1,000</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_DATE</ns1:placeholderField>
+                  <ns1:feedAttributeId>3</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>20151231 000000</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+            </ns1:operand>
+         </ns1:operations>
+      </ns1:mutate>
    </soapenv:Body>
 </soapenv:Envelope>
 ```
@@ -290,7 +290,7 @@ Next, use FeedItemService to set data to be inserted or to be set to the FeedFol
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>FeedItemService</ns1:service>
@@ -409,54 +409,54 @@ Using 'COUNTDOWN' feature will enable to display remaining minutes of discount s
 ##### Request Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:v5="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
-      <v5:RequestHeader>
-         <v5:license>XXXX-XXXX-XXXX-XXXX</v5:license>
-         <v5:apiAccountId>XXXX-XXXX-XXXX-XXXX</v5:apiAccountId>
-         <v5:apiAccountPassword>passwd</v5:apiAccountPassword>
-         <v5:accountId>100000001</v5:accountId>
-         <v5:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</v5:onBehalfOfAccountId>
-         <v5:onBehalfOfPassword>passwd2</v5:onBehalfOfPassword>
-      </v5:RequestHeader>
+      <ns1:RequestHeader>
+         <ns1:license>XXXX-XXXX-XXXX-XXXX</ns1:license>
+         <ns1:apiAccountId>XXXX-XXXX-XXXX-XXXX</ns1:apiAccountId>
+         <ns1:apiAccountPassword>passwd</ns1:apiAccountPassword>
+         <ns1:accountId>100000001</ns1:accountId>
+         <ns1:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</ns1:onBehalfOfAccountId>
+         <ns1:onBehalfOfPassword>passwd2</ns1:onBehalfOfPassword>
+      </ns1:RequestHeader>
    </soapenv:Header>
    <soapenv:Body>
-      <v5:mutate>
-         <v5:operations>
-            <v5:operator>ADD</v5:operator>
-            <v5:accountId>100000001</v5:accountId>
+      <ns1:mutate>
+         <ns1:operations>
+            <ns1:operator>ADD</ns1:operator>
+            <ns1:accountId>100000001</ns1:accountId>
             <!--1 or more repetitions:-->
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:campaignId>1001</v5:campaignId>
-               <v5:adGroupId>10001</v5:adGroupId>
-               <v5:adName>Best Practice Ad</v5:adName>
-               <v5:userStatus>ACTIVE</v5:userStatus>
-               <v5:ad xsi:type="v5:TextAd2">
-                  <v5:type>TEXT_AD2</v5:type>
-                  <v5:url>http://www.example.jp</v5:url>
-                  <v5:displayUrl>www.example.jp</v5:displayUrl>
-                  <v5:headline>人気の{=Sale product list.Product}が大特価</v5:headline>
-                  <v5:description>{=Sale product list.Price}円で販売。</v5:description>
-                  <v5:description2>終了まであと{=COUNTDOWN(Sale product list.Last sale date,"ja")}</v5:description2>
-               </v5:ad>
-            </v5:operand>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:campaignId>1002</v5:campaignId>
-               <v5:adName>Best Practice Normal Ad</v5:adName>
-               <v5:userStatus>ACTIVE</v5:userStatus>
-               <v5:ad xsi:type="v5:TextAd2">
-                  <v5:type>TEXT_AD2</v5:type>
-                  <v5:url>http://www.example.jp</v5:url>
-                  <v5:displayUrl>www.example.jp</v5:displayUrl>
-                  <v5:headline>人気の商品が大特価</v5:headline>
-                  <v5:description>期間限定特別価格で販売。</v5:description>
-                  <v5:description2>１２月３１日まで</v5:description2>
-               </v5:ad>
-            </v5:operand>
-         </v5:operations>
-      </v5:mutate>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:campaignId>1001</ns1:campaignId>
+               <ns1:adGroupId>10001</ns1:adGroupId>
+               <ns1:adName>Best Practice Ad</ns1:adName>
+               <ns1:userStatus>ACTIVE</ns1:userStatus>
+               <ns1:ad xsi:type="ns1:TextAd2">
+                  <ns1:type>TEXT_AD2</ns1:type>
+                  <ns1:url>http://www.example.jp</ns1:url>
+                  <ns1:displayUrl>www.example.jp</ns1:displayUrl>
+                  <ns1:headline>人気の{=Sale product list.Product}が大特価</ns1:headline>
+                  <ns1:description>{=Sale product list.Price}円で販売。</ns1:description>
+                  <ns1:description2>終了まであと{=COUNTDOWN(Sale product list.Last sale date,"ja")}</ns1:description2>
+               </ns1:ad>
+            </ns1:operand>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:campaignId>1002</ns1:campaignId>
+               <ns1:adName>Best Practice Normal Ad</ns1:adName>
+               <ns1:userStatus>ACTIVE</ns1:userStatus>
+               <ns1:ad xsi:type="ns1:TextAd2">
+                  <ns1:type>TEXT_AD2</ns1:type>
+                  <ns1:url>http://www.example.jp</ns1:url>
+                  <ns1:displayUrl>www.example.jp</ns1:displayUrl>
+                  <ns1:headline>人気の商品が大特価</ns1:headline>
+                  <ns1:description>期間限定特別価格で販売。</ns1:description>
+                  <ns1:description2>１２月３１日まで</ns1:description2>
+               </ns1:ad>
+            </ns1:operand>
+         </ns1:operations>
+      </ns1:mutate>
    </soapenv:Body>
 </soapenv:Envelope>
 ```
@@ -464,7 +464,7 @@ Using 'COUNTDOWN' feature will enable to display remaining minutes of discount s
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>AdGroupAdService</ns1:service>
@@ -610,65 +610,65 @@ Ad Customizers can change ad creatives automatically only with data updates, usi
 ##### Request Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:v5="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
-      <v5:RequestHeader>
-         <v5:license>XXXX-XXXX-XXXX-XXXX</v5:license>
-         <v5:apiAccountId>XXXX-XXXX-XXXX-XXXX</v5:apiAccountId>
-         <v5:apiAccountPassword>passwd</v5:apiAccountPassword>
-         <v5:accountId>100000001</v5:accountId>
-         <v5:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</v5:onBehalfOfAccountId>
-         <v5:onBehalfOfPassword>passwd2</v5:onBehalfOfPassword>
-      </v5:RequestHeader>
+      <ns1:RequestHeader>
+         <ns1:license>XXXX-XXXX-XXXX-XXXX</ns1:license>
+         <ns1:apiAccountId>XXXX-XXXX-XXXX-XXXX</ns1:apiAccountId>
+         <ns1:apiAccountPassword>passwd</ns1:apiAccountPassword>
+         <ns1:accountId>100000001</ns1:accountId>
+         <ns1:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</ns1:onBehalfOfAccountId>
+         <ns1:onBehalfOfPassword>passwd2</ns1:onBehalfOfPassword>
+      </ns1:RequestHeader>
    </soapenv:Header>
    <soapenv:Body>
-      <v5:mutate>
-         <v5:operations>
-            <v5:operator>SET</v5:operator>
-            <v5:accountId>100000001</v5:accountId>
-            <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>200001</v5:feedFolderId>
-               <v5:feedItemId>300001</v5:feedItemId>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-                  <v5:feedAttributeId>2</v5:feedAttributeId>
-                  <v5:feedAttributeValue>90</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-               <v5:targetingAdGroup>
-                  <v5:targetingAdGroupId>600001</v5:targetingAdGroupId>
-               </v5:targetingAdGroup>
-            </v5:operand>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>200001</v5:feedFolderId>
-               <v5:feedItemId>300001</v5:feedItemId>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-                  <v5:feedAttributeId>2</v5:feedAttributeId>
-                  <v5:feedAttributeValue>350</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-            </v5:operand>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>200001</v5:feedFolderId>
-               <v5:feedItemId>300001</v5:feedItemId>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-            </v5:operand>
-         </v5:operations>
-      </v5:mutate>
+      <ns1:mutate>
+         <ns1:operations>
+            <ns1:operator>SET</ns1:operator>
+            <ns1:accountId>100000001</ns1:accountId>
+            <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>200001</ns1:feedFolderId>
+               <ns1:feedItemId>300001</ns1:feedItemId>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+                  <ns1:feedAttributeId>2</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>90</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+               <ns1:targetingAdGroup>
+                  <ns1:targetingAdGroupId>600001</ns1:targetingAdGroupId>
+               </ns1:targetingAdGroup>
+            </ns1:operand>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>200001</ns1:feedFolderId>
+               <ns1:feedItemId>300001</ns1:feedItemId>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+                  <ns1:feedAttributeId>2</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>350</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+            </ns1:operand>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>200001</ns1:feedFolderId>
+               <ns1:feedItemId>300001</ns1:feedItemId>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+            </ns1:operand>
+         </ns1:operations>
+      </ns1:mutate>
    </soapenv:Body>
 </soapenv:Envelope>
 ```
@@ -676,7 +676,7 @@ Ad Customizers can change ad creatives automatically only with data updates, usi
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>FeedItemService</ns1:service>

--- a/docs/en/bestpractice/new_ss_report.md
+++ b/docs/en/bestpractice/new_ss_report.md
@@ -373,7 +373,7 @@ It requires the following:
           <ns1:format>CSV</ns1:format>
           <ns1:encode>UTF-8</ns1:encode>
           <ns1:language>EN</ns1:language>
-          <ns1:compress>OFF</ns1:compress>
+          <ns1:compress>NONE</ns1:compress>
         </ns1:operand>
       </ns1:operations>
     </ns1:mutate>
@@ -470,7 +470,7 @@ It requires the following:
             <ns1:format>CSV</ns1:format>
             <ns1:encode>UTF-8</ns1:encode>
             <ns1:language>EN</ns1:language>
-            <ns1:compress>OFF</ns1:compress>
+            <ns1:compress>NONE</ns1:compress>
           </ns1:reportDefinition>
         </ns1:values>
       </ns1:rval>

--- a/docs/en/bestpractice/ss_report.md
+++ b/docs/en/bestpractice/ss_report.md
@@ -22,7 +22,7 @@ Each report fields encapsulate the field name, field data type, and enumerations
 ##### Request Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -45,7 +45,7 @@ Each report fields encapsulate the field name, field data type, and enumerations
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>ReportDefinitionService</ns1:service>
@@ -320,7 +320,7 @@ It requires the following:
 ##### Request Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
       <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -395,7 +395,7 @@ It requires the following:
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>ReportDefinitionService</ns1:service>
@@ -478,7 +478,7 @@ Creates report from designated ReportID.
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -508,7 +508,7 @@ Creates report from designated ReportID.
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
             <ns1:service>ReportService</ns1:service>
@@ -569,7 +569,7 @@ Can confirm the report creation status.
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -600,7 +600,7 @@ or
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -629,7 +629,7 @@ or
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
             <ns1:service>ReportService</ns1:service>
@@ -690,7 +690,7 @@ Retrieves report files by designating accountID and/or reportJobID.
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -716,7 +716,7 @@ Retrieves report files by designating accountID and/or reportJobID.
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
             <ns1:service>ReportService</ns1:service>
@@ -779,7 +779,7 @@ Deletes downloaded report from ReportList.
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -809,7 +809,7 @@ Deletes downloaded report from ReportList.
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
             <ns1:service>ReportService</ns1:service>
@@ -848,7 +848,7 @@ Deletes the unnecessary defined report.
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -875,7 +875,7 @@ Deletes the unnecessary defined report.
 ##### Response Sample
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
             <ns1:service>ReportDefinitionService</ns1:service>

--- a/docs/ja/bestpractice/addisplayoption.md
+++ b/docs/ja/bestpractice/addisplayoption.md
@@ -47,7 +47,7 @@ No                | CALL_PHONE_NUMBER
 ##### ＜リクエストサンプル＞ [QUICKLINK用]
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -154,7 +154,7 @@ No                | CALL_PHONE_NUMBER
 ##### ＜レスポンスサンプル＞ [QUICKLINK用]
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>FeedItemService</ns1:service>
@@ -295,7 +295,7 @@ No                | CALL_PHONE_NUMBER
 ##### ＜リクエストサンプル＞ [CALLEXTENSION用]
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -325,7 +325,7 @@ No                | CALL_PHONE_NUMBER
 ##### ＜レスポンスサンプル＞ [CALLEXTENSION用]
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>FeedItemService</ns1:service>
@@ -364,7 +364,7 @@ No                | CALL_PHONE_NUMBER
 ##### ＜リクエストサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -413,7 +413,7 @@ No                | CALL_PHONE_NUMBER
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -485,7 +485,7 @@ No                | CALL_PHONE_NUMBER
 ##### ＜リクエストサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -529,7 +529,7 @@ No                | CALL_PHONE_NUMBER
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -587,7 +587,7 @@ No                | CALL_PHONE_NUMBER
 ##### ＜リクエストサンプル＞ [QUICKLINK用]
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -636,7 +636,7 @@ No                | CALL_PHONE_NUMBER
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -707,7 +707,7 @@ No                | CALL_PHONE_NUMBER
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -778,7 +778,7 @@ No                | CALL_PHONE_NUMBER
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -813,7 +813,7 @@ No                | CALL_PHONE_NUMBER
 ##### ＜リクエストサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -848,7 +848,7 @@ No                | CALL_PHONE_NUMBER
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
@@ -890,7 +890,7 @@ No                | CALL_PHONE_NUMBER
 ##### ＜リクエストサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V4">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -923,7 +923,7 @@ No                | CALL_PHONE_NUMBER
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V4"
+ xmlns:ns1="http://ss.yahooapis.jp/V6"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>

--- a/docs/ja/bestpractice/autoinsert_data.md
+++ b/docs/ja/bestpractice/autoinsert_data.md
@@ -101,41 +101,41 @@ A社は、販促施策の一環として、スポンサードサーチAPIを使�
 ##### リクエストサンプル
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:v5="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
-      <v5:RequestHeader>
-         <v5:license>XXXX-XXXX-XXXX-XXXX</v5:license>
-         <v5:apiAccountId>XXXX-XXXX-XXXX-XXXX</v5:apiAccountId>
-         <v5:apiAccountPassword>passwd</v5:apiAccountPassword>
-         <v5:accountId>100000001</v5:accountId>
-         <v5:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</v5:onBehalfOfAccountId>
-         <v5:onBehalfOfPassword>passwd2</v5:onBehalfOfPassword>
-      </v5:RequestHeader>
+      <ns1:RequestHeader>
+         <ns1:license>XXXX-XXXX-XXXX-XXXX</ns1:license>
+         <ns1:apiAccountId>XXXX-XXXX-XXXX-XXXX</ns1:apiAccountId>
+         <ns1:apiAccountPassword>passwd</ns1:apiAccountPassword>
+         <ns1:accountId>100000001</ns1:accountId>
+         <ns1:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</ns1:onBehalfOfAccountId>
+         <ns1:onBehalfOfPassword>passwd2</ns1:onBehalfOfPassword>
+      </ns1:RequestHeader>
    </soapenv:Header>
    <soapenv:Body>
-      <v5:mutate>
-         <v5:operations>
-            <v5:operator>ADD</v5:operator>
-            <v5:accountId>100000001</v5:accountId>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderName>セール商品リスト</v5:feedFolderName>
-               <v5:feedAttribute>
-                  <v5:feedAttributeName>商品名</v5:feedAttributeName>
-                  <v5:placeholderField>AD_CUSTOMIZER_STRING</v5:placeholderField>
-               </v5:feedAttribute>
-               <v5:feedAttribute>
-                  <v5:feedAttributeName>価格</v5:feedAttributeName>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-               </v5:feedAttribute>
-               <v5:feedAttribute>
-                  <v5:feedAttributeName>セール終了日</v5:feedAttributeName>
-                  <v5:placeholderField>AD_CUSTOMIZER_DATE</v5:placeholderField>
-               </v5:feedAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-            </v5:operand>
-         </v5:operations>
-      </v5:mutate>
+      <ns1:mutate>
+         <ns1:operations>
+            <ns1:operator>ADD</ns1:operator>
+            <ns1:accountId>100000001</ns1:accountId>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderName>セール商品リスト</ns1:feedFolderName>
+               <ns1:feedAttribute>
+                  <ns1:feedAttributeName>商品名</ns1:feedAttributeName>
+                  <ns1:placeholderField>AD_CUSTOMIZER_STRING</ns1:placeholderField>
+               </ns1:feedAttribute>
+               <ns1:feedAttribute>
+                  <ns1:feedAttributeName>価格</ns1:feedAttributeName>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+               </ns1:feedAttribute>
+               <ns1:feedAttribute>
+                  <ns1:feedAttributeName>セール終了日</ns1:feedAttributeName>
+                  <ns1:placeholderField>AD_CUSTOMIZER_DATE</ns1:placeholderField>
+               </ns1:feedAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+            </ns1:operand>
+         </ns1:operations>
+      </ns1:mutate>
    </soapenv:Body>
 </soapenv:Envelope>
 ```
@@ -143,7 +143,7 @@ A社は、販促施策の一環として、スポンサードサーチAPIを使�
 ##### レスポンスサンプル
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>FeedFolderService</ns1:service>
@@ -193,97 +193,97 @@ A社は、販促施策の一環として、スポンサードサーチAPIを使�
 ##### リクエストサンプル
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:v5="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
-      <v5:RequestHeader>
-         <v5:license>XXXX-XXXX-XXXX-XXXX</v5:license>
-         <v5:apiAccountId>XXXX-XXXX-XXXX-XXXX</v5:apiAccountId>
-         <v5:apiAccountPassword>passwd</v5:apiAccountPassword>
-         <v5:accountId>100000001</v5:accountId>
-         <v5:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</v5:onBehalfOfAccountId>
-         <v5:onBehalfOfPassword>passwd2</v5:onBehalfOfPassword>
-      </v5:RequestHeader>
+      <ns1:RequestHeader>
+         <ns1:license>XXXX-XXXX-XXXX-XXXX</ns1:license>
+         <ns1:apiAccountId>XXXX-XXXX-XXXX-XXXX</ns1:apiAccountId>
+         <ns1:apiAccountPassword>passwd</ns1:apiAccountPassword>
+         <ns1:accountId>100000001</ns1:accountId>
+         <ns1:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</ns1:onBehalfOfAccountId>
+         <ns1:onBehalfOfPassword>passwd2</ns1:onBehalfOfPassword>
+      </ns1:RequestHeader>
    </soapenv:Header>
    <soapenv:Body>
-      <v5:mutate>
-         <v5:operations>
-            <v5:operator>ADD</v5:operator>
-            <v5:accountId>100000001</v5:accountId>
-            <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>20001</v5:feedFolderId>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_STRING</v5:placeholderField>
-                  <v5:feedAttributeId>1</v5:feedAttributeId>
-                  <v5:feedAttributeValue>製品101</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-                  <v5:feedAttributeId>2</v5:feedAttributeId>
-                  <v5:feedAttributeValue>100</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_DATE</v5:placeholderField>
-                  <v5:feedAttributeId>3</v5:feedAttributeId>
-                  <v5:feedAttributeValue>20151231 000000</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-               <v5:targetingAdGroup>
-                  <v5:targetingAdGroupId>600001</v5:targetingAdGroupId>
-               </v5:targetingAdGroup>
-            </v5:operand>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>20001</v5:feedFolderId>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_STRING</v5:placeholderField>
-                  <v5:feedAttributeId>1</v5:feedAttributeId>
-                  <v5:feedAttributeValue>製品102</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-                  <v5:feedAttributeId>2</v5:feedAttributeId>
-                  <v5:feedAttributeValue>300</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_DATE</v5:placeholderField>
-                  <v5:feedAttributeId>3</v5:feedAttributeId>
-                  <v5:feedAttributeValue>20151231 000000</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-            </v5:operand>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>53161</v5:feedFolderId>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_STRING</v5:placeholderField>
-                  <v5:feedAttributeId>1</v5:feedAttributeId>
-                  <v5:feedAttributeValue>製品103</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-                  <v5:feedAttributeId>2</v5:feedAttributeId>
-                  <v5:feedAttributeValue>1,000</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_DATE</v5:placeholderField>
-                  <v5:feedAttributeId>3</v5:feedAttributeId>
-                  <v5:feedAttributeValue>20151231 000000</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-            </v5:operand>
-         </v5:operations>
-      </v5:mutate>
+      <ns1:mutate>
+         <ns1:operations>
+            <ns1:operator>ADD</ns1:operator>
+            <ns1:accountId>100000001</ns1:accountId>
+            <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>20001</ns1:feedFolderId>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_STRING</ns1:placeholderField>
+                  <ns1:feedAttributeId>1</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>製品101</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+                  <ns1:feedAttributeId>2</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>100</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_DATE</ns1:placeholderField>
+                  <ns1:feedAttributeId>3</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>20151231 000000</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+               <ns1:targetingAdGroup>
+                  <ns1:targetingAdGroupId>600001</ns1:targetingAdGroupId>
+               </ns1:targetingAdGroup>
+            </ns1:operand>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>20001</ns1:feedFolderId>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_STRING</ns1:placeholderField>
+                  <ns1:feedAttributeId>1</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>製品102</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+                  <ns1:feedAttributeId>2</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>300</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_DATE</ns1:placeholderField>
+                  <ns1:feedAttributeId>3</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>20151231 000000</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+            </ns1:operand>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>53161</ns1:feedFolderId>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_STRING</ns1:placeholderField>
+                  <ns1:feedAttributeId>1</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>製品103</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+                  <ns1:feedAttributeId>2</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>1,000</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_DATE</ns1:placeholderField>
+                  <ns1:feedAttributeId>3</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>20151231 000000</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+            </ns1:operand>
+         </ns1:operations>
+      </ns1:mutate>
    </soapenv:Body>
 </soapenv:Envelope>
 ```
@@ -291,7 +291,7 @@ A社は、販促施策の一環として、スポンサードサーチAPIを使�
 ##### レスポンスサンプル
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>FeedItemService</ns1:service>
@@ -410,54 +410,54 @@ A社は、販促施策の一環として、スポンサードサーチAPIを使�
 ##### リクエストサンプル
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:v5="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
-      <v5:RequestHeader>
-         <v5:license>XXXX-XXXX-XXXX-XXXX</v5:license>
-         <v5:apiAccountId>XXXX-XXXX-XXXX-XXXX</v5:apiAccountId>
-         <v5:apiAccountPassword>passwd</v5:apiAccountPassword>
-         <v5:accountId>100000001</v5:accountId>
-         <v5:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</v5:onBehalfOfAccountId>
-         <v5:onBehalfOfPassword>passwd2</v5:onBehalfOfPassword>
-      </v5:RequestHeader>
+      <ns1:RequestHeader>
+         <ns1:license>XXXX-XXXX-XXXX-XXXX</ns1:license>
+         <ns1:apiAccountId>XXXX-XXXX-XXXX-XXXX</ns1:apiAccountId>
+         <ns1:apiAccountPassword>passwd</ns1:apiAccountPassword>
+         <ns1:accountId>100000001</ns1:accountId>
+         <ns1:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</ns1:onBehalfOfAccountId>
+         <ns1:onBehalfOfPassword>passwd2</ns1:onBehalfOfPassword>
+      </ns1:RequestHeader>
    </soapenv:Header>
    <soapenv:Body>
-      <v5:mutate>
-         <v5:operations>
-            <v5:operator>ADD</v5:operator>
-            <v5:accountId>100000001</v5:accountId>
+      <ns1:mutate>
+         <ns1:operations>
+            <ns1:operator>ADD</ns1:operator>
+            <ns1:accountId>100000001</ns1:accountId>
             <!--1 or more repetitions:-->
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:campaignId>1001</v5:campaignId>
-               <v5:adGroupId>10001</v5:adGroupId>
-               <v5:adName>Best Practice Ad</v5:adName>
-               <v5:userStatus>ACTIVE</v5:userStatus>
-               <v5:ad xsi:type="v5:TextAd2">
-                  <v5:type>TEXT_AD2</v5:type>
-                  <v5:url>http://www.example.jp</v5:url>
-                  <v5:displayUrl>www.example.jp</v5:displayUrl>
-                  <v5:headline>人気の{=セール商品リスト.商品名}が大特価</v5:headline>
-                  <v5:description>{=セール商品リスト.価格}円で販売。</v5:description>
-                  <v5:description2>終了まであと{=COUNTDOWN(セール商品リスト.セール終了日,"ja")}</v5:description2>
-               </v5:ad>
-            </v5:operand>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:campaignId>1002</v5:campaignId>
-               <v5:adName>Best Practice Normal Ad</v5:adName>
-               <v5:userStatus>ACTIVE</v5:userStatus>
-               <v5:ad xsi:type="v5:TextAd2">
-                  <v5:type>TEXT_AD2</v5:type>
-                  <v5:url>http://www.example.jp</v5:url>
-                  <v5:displayUrl>www.example.jp</v5:displayUrl>
-                  <v5:headline>人気の商品が大特価</v5:headline>
-                  <v5:description>期間限定特別価格で販売。</v5:description>
-                  <v5:description2>１２月３１日まで</v5:description2>
-               </v5:ad>
-            </v5:operand>
-         </v5:operations>
-      </v5:mutate>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:campaignId>1001</ns1:campaignId>
+               <ns1:adGroupId>10001</ns1:adGroupId>
+               <ns1:adName>Best Practice Ad</ns1:adName>
+               <ns1:userStatus>ACTIVE</ns1:userStatus>
+               <ns1:ad xsi:type="ns1:TextAd2">
+                  <ns1:type>TEXT_AD2</ns1:type>
+                  <ns1:url>http://www.example.jp</ns1:url>
+                  <ns1:displayUrl>www.example.jp</ns1:displayUrl>
+                  <ns1:headline>人気の{=セール商品リスト.商品名}が大特価</ns1:headline>
+                  <ns1:description>{=セール商品リスト.価格}円で販売。</ns1:description>
+                  <ns1:description2>終了まであと{=COUNTDOWN(セール商品リスト.セール終了日,"ja")}</ns1:description2>
+               </ns1:ad>
+            </ns1:operand>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:campaignId>1002</ns1:campaignId>
+               <ns1:adName>Best Practice Normal Ad</ns1:adName>
+               <ns1:userStatus>ACTIVE</ns1:userStatus>
+               <ns1:ad xsi:type="ns1:TextAd2">
+                  <ns1:type>TEXT_AD2</ns1:type>
+                  <ns1:url>http://www.example.jp</ns1:url>
+                  <ns1:displayUrl>www.example.jp</ns1:displayUrl>
+                  <ns1:headline>人気の商品が大特価</ns1:headline>
+                  <ns1:description>期間限定特別価格で販売。</ns1:description>
+                  <ns1:description2>１２月３１日まで</ns1:description2>
+               </ns1:ad>
+            </ns1:operand>
+         </ns1:operations>
+      </ns1:mutate>
    </soapenv:Body>
 </soapenv:Envelope>
 ```
@@ -465,7 +465,7 @@ A社は、販促施策の一環として、スポンサードサーチAPIを使�
 ##### レスポンスサンプル
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>AdGroupAdService</ns1:service>
@@ -611,65 +611,65 @@ A社は、販促施策の一環として、スポンサードサーチAPIを使�
 ##### リクエストサンプル
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:v5="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
-      <v5:RequestHeader>
-         <v5:license>XXXX-XXXX-XXXX-XXXX</v5:license>
-         <v5:apiAccountId>XXXX-XXXX-XXXX-XXXX</v5:apiAccountId>
-         <v5:apiAccountPassword>passwd</v5:apiAccountPassword>
-         <v5:accountId>100000001</v5:accountId>
-         <v5:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</v5:onBehalfOfAccountId>
-         <v5:onBehalfOfPassword>passwd2</v5:onBehalfOfPassword>
-      </v5:RequestHeader>
+      <ns1:RequestHeader>
+         <ns1:license>XXXX-XXXX-XXXX-XXXX</ns1:license>
+         <ns1:apiAccountId>XXXX-XXXX-XXXX-XXXX</ns1:apiAccountId>
+         <ns1:apiAccountPassword>passwd</ns1:apiAccountPassword>
+         <ns1:accountId>100000001</ns1:accountId>
+         <ns1:onBehalfOfAccountId>XXXXX-XXXX-XXXXX-XXXX</ns1:onBehalfOfAccountId>
+         <ns1:onBehalfOfPassword>passwd2</ns1:onBehalfOfPassword>
+      </ns1:RequestHeader>
    </soapenv:Header>
    <soapenv:Body>
-      <v5:mutate>
-         <v5:operations>
-            <v5:operator>SET</v5:operator>
-            <v5:accountId>100000001</v5:accountId>
-            <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>200001</v5:feedFolderId>
-               <v5:feedItemId>300001</v5:feedItemId>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-                  <v5:feedAttributeId>2</v5:feedAttributeId>
-                  <v5:feedAttributeValue>90</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-               <v5:targetingAdGroup>
-                  <v5:targetingAdGroupId>600001</v5:targetingAdGroupId>
-               </v5:targetingAdGroup>
-            </v5:operand>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>200001</v5:feedFolderId>
-               <v5:feedItemId>300001</v5:feedItemId>
-               <v5:feedItemAttribute>
-                  <v5:placeholderField>AD_CUSTOMIZER_PRICE</v5:placeholderField>
-                  <v5:feedAttributeId>2</v5:feedAttributeId>
-                  <v5:feedAttributeValue>350</v5:feedAttributeValue>
-               </v5:feedItemAttribute>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-            </v5:operand>
-            <v5:operand>
-               <v5:accountId>100000001</v5:accountId>
-               <v5:feedFolderId>200001</v5:feedFolderId>
-               <v5:feedItemId>300001</v5:feedItemId>
-               <v5:placeholderType>AD_CUSTOMIZER</v5:placeholderType>
-               <v5:targetingCampaign>
-                  <v5:targetingCampaignId>500001</v5:targetingCampaignId>
-               </v5:targetingCampaign>
-            </v5:operand>
-         </v5:operations>
-      </v5:mutate>
+      <ns1:mutate>
+         <ns1:operations>
+            <ns1:operator>SET</ns1:operator>
+            <ns1:accountId>100000001</ns1:accountId>
+            <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>200001</ns1:feedFolderId>
+               <ns1:feedItemId>300001</ns1:feedItemId>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+                  <ns1:feedAttributeId>2</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>90</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+               <ns1:targetingAdGroup>
+                  <ns1:targetingAdGroupId>600001</ns1:targetingAdGroupId>
+               </ns1:targetingAdGroup>
+            </ns1:operand>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>200001</ns1:feedFolderId>
+               <ns1:feedItemId>300001</ns1:feedItemId>
+               <ns1:feedItemAttribute>
+                  <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
+                  <ns1:feedAttributeId>2</ns1:feedAttributeId>
+                  <ns1:feedAttributeValue>350</ns1:feedAttributeValue>
+               </ns1:feedItemAttribute>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+            </ns1:operand>
+            <ns1:operand>
+               <ns1:accountId>100000001</ns1:accountId>
+               <ns1:feedFolderId>200001</ns1:feedFolderId>
+               <ns1:feedItemId>300001</ns1:feedItemId>
+               <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
+               <ns1:targetingCampaign>
+                  <ns1:targetingCampaignId>500001</ns1:targetingCampaignId>
+               </ns1:targetingCampaign>
+            </ns1:operand>
+         </ns1:operations>
+      </ns1:mutate>
    </soapenv:Body>
 </soapenv:Envelope>
 ```
@@ -677,7 +677,7 @@ A社は、販促施策の一環として、スポンサードサーチAPIを使�
 ##### レスポンスサンプル
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>FeedItemService</ns1:service>

--- a/docs/ja/bestpractice/new_ss_report.md
+++ b/docs/ja/bestpractice/new_ss_report.md
@@ -370,7 +370,7 @@ ReportDefinitionServiceのmutate:addを使用します。
           <ns1:format>CSV</ns1:format>
           <ns1:encode>UTF-8</ns1:encode>
           <ns1:language>EN</ns1:language>
-          <ns1:compress>OFF</ns1:compress>
+          <ns1:compress>NONE</ns1:compress>
         </ns1:operand>
       </ns1:operations>
     </ns1:mutate>
@@ -467,7 +467,7 @@ ReportDefinitionServiceのmutate:addを使用します。
             <ns1:format>CSV</ns1:format>
             <ns1:encode>UTF-8</ns1:encode>
             <ns1:language>EN</ns1:language>
-            <ns1:compress>OFF</ns1:compress>
+            <ns1:compress>NONE</ns1:compress>
           </ns1:reportDefinition>
         </ns1:values>
       </ns1:rval>

--- a/docs/ja/bestpractice/ss_report.md
+++ b/docs/ja/bestpractice/ss_report.md
@@ -24,7 +24,7 @@ ReportTypeを指定して、利用可能なレポートフィールドのリス�
 ##### ＜リクエストサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
       <ns1:RequestHeader>
          <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -47,7 +47,7 @@ ReportTypeを指定して、利用可能なレポートフィールドのリス�
 ##### ＜レスポンスサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>ReportDefinitionService</ns1:service>
@@ -321,7 +321,7 @@ ReportDefinitionServiceのmutate:addを使用します。
 ##### ＜リクエストサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <soapenv:Header>
       <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -396,7 +396,7 @@ ReportDefinitionServiceのmutate:addを使用します。
 ##### ＜レスポンスサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
    <SOAP-ENV:Header>
       <ns1:ResponseHeader>
          <ns1:service>ReportDefinitionService</ns1:service>
@@ -478,7 +478,7 @@ ReportServiceのmutate:addを使用します。指定のReportIDでレポート�
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -508,7 +508,7 @@ ReportServiceのmutate:addを使用します。指定のReportIDでレポート�
 ##### ＜レスポンスサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
             <ns1:service>ReportService</ns1:service>
@@ -569,7 +569,7 @@ ReportServiceのgetを使用します。
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -600,7 +600,7 @@ or
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -629,7 +629,7 @@ or
 ##### ＜レスポンスサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
             <ns1:service>ReportService</ns1:service>
@@ -690,7 +690,7 @@ accountID,reportJobIDを指定し、レポートファイルを取得します�
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -716,7 +716,7 @@ accountID,reportJobIDを指定し、レポートファイルを取得します�
 ##### ＜レスポンスサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
             <ns1:service>ReportService</ns1:service>
@@ -779,7 +779,7 @@ ReportServiceのmutate:removeを使用します。
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -809,7 +809,7 @@ ReportServiceのmutate:removeを使用します。
 ##### ＜レスポンスサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
             <ns1:service>ReportService</ns1:service>
@@ -848,7 +848,7 @@ ReportDefinitionServiceのmutate:removeを使用します。
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope
  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
- xmlns:ns1="http://ss.yahooapis.jp/V5">
+ xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:RequestHeader>
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
@@ -875,7 +875,7 @@ ReportDefinitionServiceのmutate:removeを使用します。
 ##### ＜レスポンスサンプル＞
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V5">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.yahooapis.jp/V6">
     <SOAP-ENV:Header>
         <ns1:ResponseHeader>
             <ns1:service>ReportDefinitionService</ns1:service>


### PR DESCRIPTION
All example requests in bestpractice fail due to API version.

```xml
    <SOAP-ENV:Fault>
      <faultcode>SOAP-ENV:Server</faultcode>
      <faultstring>Procedure 'mutate' not present</faultstring>
    </SOAP-ENV:Fault>
```

This PR updates versions from `V4`, `V5` to `V6`.
Thanks.