### PR TITLE
SOAP reqeust/response XML format fixes

### DIFF
--- a/docs/en/api_reference/services/BalanceService.md
+++ b/docs/en/api_reference/services/BalanceService.md
@@ -30,7 +30,7 @@ Returns account balance.
             <ns1:license>xxxx-xxxx-xxxx-xxxx</ns1:license>
             <ns1:apiAccountId>xxxx-xxxx-xxxx-xxxx</ns1:apiAccountId>
             <ns1:apiAccountPassword>passwd</ns1:apiAccountPassword>
-        <ns1:RequestHeader>
+        </ns1:RequestHeader>
     </SOAP-ENV:Header>
     <SOAP-ENV:Body>
         <ns1:get>
@@ -60,7 +60,7 @@ Returns account balance.
             <ns1:apiAccountPassword>passwd</ns1:apiAccountPassword>
             <ns1:onBehalfOfAccountId>xxxxxxxxxxxxxx</ns1:onBehalfOfAccountId> 
             <ns1:onBehalfOfPassword>passwd2</ns1:onBehalfOfPassword>
-        <ns1:RequestHeader>
+        </ns1:RequestHeader>
     </SOAP-ENV:Header>
     <SOAP-ENV:Body>
         <ns1:get>

--- a/docs/en/api_reference/services/DictionaryService.md
+++ b/docs/en/api_reference/services/DictionaryService.md
@@ -92,31 +92,31 @@ xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://ss.
                 <ns1:values>
                     <ns1:operationSucceeded>true</ns1:operationSucceeded>
                     <ns1:disapprovalReason>
-                        <ns1:disapprovalReasonCode>1<ns1:disapprovalReasonCode>
-                        <ns1:lang>JA<ns1:lang>
-                        <ns1:title>disapprovalReasonタイトル<ns1:title>
-                        <ns1:description>disapprovalReason説明<ns1:description>
-                        <ns1:recommend>対処方法<ns1:recommend>
+                        <ns1:disapprovalReasonCode>1</ns1:disapprovalReasonCode>
+                        <ns1:lang>JA</ns1:lang>
+                        <ns1:title>disapprovalReasonタイトル</ns1:title>
+                        <ns1:description>disapprovalReason説明</ns1:description>
+                        <ns1:recommend>対処方法</ns1:recommend>
                     </ns1:disapprovalReason>
                 </ns1:values>
                 <ns1:values>
                     <ns1:operationSucceeded>true</ns1:operationSucceeded>
                     <ns1:disapprovalReason>
-                        <ns1:desapprovalReasonCode>2<ns1:disapprovalReasonCode>
-                        <ns1:lang>JA<ns1:lang>
-                        <ns1:title>disapprovalReasonタイトル2<ns1:title>
-                        <ns1:description>disapprovalReason説明2<ns1:description>
-                        <ns1:recommend>対処方法2<ns1:recommend>
+                        <ns1:disapprovalReasonCode>2</ns1:disapprovalReasonCode>
+                        <ns1:lang>JA</ns1:lang>
+                        <ns1:title>disapprovalReasonタイトル2</ns1:title>
+                        <ns1:description>disapprovalReason説明2</ns1:description>
+                        <ns1:recommend>対処方法2</ns1:recommend>
                     </ns1:disapprovalReason>
                 </ns1:values>
                 <ns1:values>
                     <ns1:operationSucceeded>true</ns1:operationSucceeded>
                     <ns1:disapprovalReason>
-                        <ns1:disapprovalReasonCode>3<ns1:disapprovalReasonCode>
-                        <ns1:lang>JA<ns1:lang>
-                        <ns1:title>disapprovalReasonタイトル3<ns1:title>
-                        <ns1:description>disapprovalReason説明3<ns1:description>
-                        <ns1:recommend>対処方法3<ns1:recommend>
+                        <ns1:disapprovalReasonCode>3</ns1:disapprovalReasonCode>
+                        <ns1:lang>JA</ns1:lang>
+                        <ns1:title>disapprovalReasonタイトル3</ns1:title>
+                        <ns1:description>disapprovalReason説明3</ns1:description>
+                        <ns1:recommend>対処方法3</ns1:recommend>
                     </ns1:disapprovalReason>
                 </ns1:values>
             </ns1:rval>

--- a/docs/en/api_reference/services/FeedFolderService.md
+++ b/docs/en/api_reference/services/FeedFolderService.md
@@ -114,12 +114,12 @@ Response Fields
                         <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
                         <ns1:feedAttribute>
                             <ns1:feedAttributeId>2000000001</ns1:feedAttributeId>
-                            <ns1:feedAttributeName>myfeedattname1</ns1:feed AttributeName>
+                            <ns1:feedAttributeName>myfeedattname1</ns1:feedAttributeName>
                             <ns1:placeholderField>AD_CUSTOMIZER_INTEGER</ns1:placeholderField>
                         </ns1:feedAttribute>
                         <ns1:feedAttribute>
                             <ns1:feedAttributeId>2000000002</ns1:feedAttributeId>
-                            <ns1:feedAttributeName>myfeedattname2</ns1:feed AttributeName>
+                            <ns1:feedAttributeName>myfeedattname2</ns1:feedAttributeName>
                             <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
                         </ns1:feedAttribute>
                     </ns1:feedFolder>
@@ -159,11 +159,11 @@ Add the information related to Feed Folder.
                     <ns1:feedFolderName>myfeedname</ns1:feedFolderName>
                     <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
                     <ns1:feedAttribute>
-                        <ns1:feedAttributeName>myfeedattname1</ns1:feed AttributeName>
+                        <ns1:feedAttributeName>myfeedattname1</ns1:feedAttributeName>
                         <ns1:placeholderField>AD_CUSTOMIZER_INTEGER</ns1:placeholderField>
                     </ns1:feedAttribute>
                     <ns1:feedAttribute>
-                        <ns1:feedAttributeName>myfeedattname2</ns1:feed AttributeName>
+                        <ns1:feedAttributeName>myfeedattname2</ns1:feedAttributeName>
                         <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
                     </ns1:feedAttribute>
                 </ns1:operand>
@@ -196,11 +196,11 @@ Add the information related to Feed Folder.
                     <ns1:feedFolderName>myfeedname</ns1:feedFolderName>
                     <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
                     <ns1:feedAttribute>
-                        <ns1:feedAttributeName>myfeedattname1</ns1:feed AttributeName>
+                        <ns1:feedAttributeName>myfeedattname1</ns1:feedAttributeName>
                         <ns1:placeholderField>AD_CUSTOMIZER_INTEGER</ns1:placeholderField>
                     </ns1:feedAttribute>
                     <ns1:feedAttribute>
-                        <ns1:feedAttributeName>myfeedattname2</ns1:feed AttributeName>
+                        <ns1:feedAttributeName>myfeedattname2</ns1:feedAttributeName>
                         <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
                     </ns1:feedAttribute>
                 </ns1:operand>
@@ -245,12 +245,12 @@ Response Fields
                         <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholde Type>
                         <ns1:feedAttribute>
                             <ns1:feedAttributeId>2000000001</ns1:feedAttributeId>
-                            <ns1:feedAttributeName>myfeedattname1</ns1:feed AttributeName>
+                            <ns1:feedAttributeName>myfeedattname1</ns1:feedAttributeName>
                             <ns1:placeholderField>AD_CUSTOMIZER_INTEGER</ns1:placeholderField>
                         </ns1:feedAttribute>
                         <ns1:feedAttribute>
                             <ns1:feedAttributeId>2000000002</ns1:feedAttributeId>
-                            <ns1:feedAttributeName>myfeedattname2</ns1:feed AttributeName>
+                            <ns1:feedAttributeName>myfeedattname2</ns1:feedAttributeName>
                             <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
                         </ns1:feedAttribute>
                     </ns1:feedFolder>
@@ -294,7 +294,7 @@ Updates Feed Folder information.
                         <ns1:placeholderField>AD_CUSTOMIZER_INTEGER</ns1:placeholderField>
                     </ns1:feedAttribute>
                     <ns1:feedAttribute>
-                        <ns1:feedAttributeName>myfeedattname2</ns1:feed AttributeName>
+                        <ns1:feedAttributeName>myfeedattname2</ns1:feedAttributeName>
                         <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
                     </ns1:feedAttribute>
                 </ns1:operand>
@@ -330,7 +330,7 @@ Updates Feed Folder information.
                         <ns1:placeholderField>AD_CUSTOMIZER_INTEGER</ns1:placeholderField>
                     </ns1:feedAttribute>
                     <ns1:feedAttribute>
-                        <ns1:feedAttributeName>myfeedattname2</ns1:feed AttributeName>
+                        <ns1:feedAttributeName>myfeedattname2</ns1:feedAttributeName>
                         <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
                     </ns1:feedAttribute>
                 </ns1:operand>
@@ -380,7 +380,7 @@ Response Fields
                         </ns1:feedAttribute>
                         <ns1:feedAttribute>
                             <ns1:feedAttributeId>2000000002</ns1:feedAttributeId>
-                            <ns1:feedAttributeName>myfeedattname2</ns1:feed AttributeName>
+                            <ns1:feedAttributeName>myfeedattname2</ns1:feedAttributeName>
                             <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
                         </ns1:feedAttribute>
                     </ns1:feedFolder>
@@ -495,7 +495,7 @@ Response Fields
                         </ns1:feedAttribute>
                         <ns1:feedAttribute>
                             <ns1:feedAttributeId>2000000002</ns1:feedAttributeId>
-                            <ns1:feedAttributeName>myfeedattname2</ns1:feed AttributeName>
+                            <ns1:feedAttributeName>myfeedattname2</ns1:feedAttributeName>
                             <ns1:placeholderField>AD_CUSTOMIZER_PRICE</ns1:placeholderField>
                         </ns1:feedAttribute>
                     </ns1:feedFolder>

--- a/docs/en/api_reference/services/FeedFolderService.md
+++ b/docs/en/api_reference/services/FeedFolderService.md
@@ -242,7 +242,7 @@ Response Fields
                         <ns1:accountId>1000000001</ns1:accountId>
                         <ns1:feedFolderId>113</ns1:feedFolderId>
                         <ns1:feedFolderName>myfeedname</ns1:feedFolderName>
-                        <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholde Type>
+                        <ns1:placeholderType>AD_CUSTOMIZER</ns1:placeholderType>
                         <ns1:feedAttribute>
                             <ns1:feedAttributeId>2000000001</ns1:feedAttributeId>
                             <ns1:feedAttributeName>myfeedattname1</ns1:feedAttributeName>


### PR DESCRIPTION
Hi, 
I am the developer of the [yahooads-python-lib](https://github.com/becomejapan/yahooads-python-lib) python library. I use `/docs/en/api_reference/services/XXXServeice.md` files to auto-generate sample code for the library. In the process, I came across some xml errors in the request/response SOAP messages which throws off my `xmltodict.parse()` phase. This pull request contains the corrections for `.md` files which removes most of the issues for my work.
Also feel free to include/improve my python library along with your API documentation. We (at Become Japan Corp.) developed this library because we wanted a similar solution like [googleads-python-lib](https://github.com/googleads/googleads-python-lib). Your feedback is welcome.
