### PR TITLE
Fix incorrect instruction for ReportFilter.value

### DIFF
--- a/docs/en/api_reference/data/ReportDefinition/ReportFilter.md
+++ b/docs/en/api_reference/data/ReportDefinition/ReportFilter.md
@@ -41,7 +41,7 @@ Filter condition can set up to 6.
  </tr>
   <td>value[0...200]</td>
   <td>xsd:string</td>
-  <td>Condition values to filter the field. <br>Use comma(,) to filter multiple fields.</td>
+  <td>Condition values to filter the field. </td>
   <td>yes</td>
   <td>-</td>
   <td>Requirement</td>

--- a/docs/ja/api_reference/data/ReportDefinition/ReportFilter.md
+++ b/docs/ja/api_reference/data/ReportDefinition/ReportFilter.md
@@ -40,7 +40,7 @@ ReportFilterオブジェクトは、レポートのフィルタ条件を表し�
  </tr>
   <td>value[0...200]</td>
   <td>xsd:string</td>
-  <td>表示項目の条件値です。<br>複数する場合は、カンマ 区切り（,）で指定します。</td>
+  <td>表示項目の条件値です。</td>
   <td>yes</td>
   <td>-</td>
   <td>Requirement</td>


### PR DESCRIPTION
I recently had some experiment to use "IN" operator in ReportFilter object and found these:
- wrong instruction: value should be comma separated string. `<value>aaa,bbb</value>`
- correct instruction: value should be array of string. `<value>aaa</value><value>bbb</value>`

And the WSDL was correct, it says `maxOccurs="unbounded"`.
Please fix the misleading document.

